### PR TITLE
Fix: #6 - Allow to specify platform version

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,20 @@ var Q = require('q');
 var cordovaLib = require('cordova-lib').cordova;
 var cordova = cordovaLib.raw;
 
-module.exports = function (rm) {
+module.exports = function (options) {
+	options = options || {};
+	var rm, version;
+	if (typeof options === 'object') {
+		if (typeof options.version !== 'undefined') {
+			version = options.version;
+		}
+		if (typeof version.reAdd !== 'undefined') {
+			rm = options.reAdd;
+		}
+	} else {
+		rm = options; // backward compatibility
+	}
+	
 	return through.obj(function (file, enc, cb) {
 		// Change the working directory
 		process.env.PWD = file.path;
@@ -28,7 +41,7 @@ module.exports = function (rm) {
 		}).then(function () {
 			if (exists === false || reAdd) {
 				// Add the iOS platform if it does not exist or we have to re-add it
-				return cordova.platforms('add', 'ios');
+				return cordova.platforms('add', 'ios' + (version? ('@'+version) : ''));
 			}
 		}).then(function () {
 			// Build the platform

--- a/index.js
+++ b/index.js
@@ -9,18 +9,7 @@ var cordova = cordovaLib.raw;
 
 module.exports = function (options) {
 	options = options || {};
-	var rm, version;
-	if (typeof options === 'object') {
-		if (typeof options.version !== 'undefined') {
-			version = options.version;
-		}
-		if (typeof version.reAdd !== 'undefined') {
-			rm = options.reAdd;
-		}
-	} else {
-		rm = options; // backward compatibility
-	}
-	
+
 	return through.obj(function (file, enc, cb) {
 		// Change the working directory
 		process.env.PWD = file.path;
@@ -31,17 +20,16 @@ module.exports = function (options) {
 		cb();
 	}, function (cb) {
 		var exists = fs.existsSync(path.join(cordovaLib.findProjectRoot(), 'platforms', 'ios'));
-		var reAdd = exists === true && rm === true;
 
 		Q.fcall(function () {
-			if (reAdd) {
+			if (options.reAdd) {
 				// First remove the platform if we have to re-add it
 				return cordova.platforms('rm', 'ios');
 			}
 		}).then(function () {
-			if (exists === false || reAdd) {
+			if (exists === false || options.reAdd) {
 				// Add the iOS platform if it does not exist or we have to re-add it
-				return cordova.platforms('add', 'ios' + (version? ('@'+version) : ''));
+				return cordova.platforms('add', 'ios' + (options.version? ('@'+options.version) : ''));
 			}
 		}).then(function () {
 			// Build the platform

--- a/readme.md
+++ b/readme.md
@@ -30,53 +30,25 @@ gulp.task('build', () => {
 This plugin will build the cordova project for the iOS platform.
 
 ## API
-### ios(options)
-#### options
 
-*Optional*
+### ios(options)
+
+#### options
 
 Type: `object`
 
-A key-value pair object where the key is the name of the preference and the value the value. The keys and types are described below.
+##### reAdd 
 
-##### options.reAdd 
-
-*Optional*
-
-Type: `boolean`
+Type: `boolean`  
+Default: `false`
 
 If the value is `true`, this will cause the ios platform to be removed and re-added. 
 
-#### options.version
-
-*Optional*
+#### version
 
 Type: `string`
 
-This will force the cordova to get the specified platform version of ios platform support.
-
-## Example
-
-```js
-const gulp = require('gulp');
-const ios = require('gulp-cordova-build-ios');
-
-gulp.task('rebuild', () => {
-    return gulp.src('.cordova')
-        .pipe(ios({ version: '3.9.2' }));
-});
-```
-
-This task will simply remove the iOS platform, add it again and rebuild it.
-
-```
-$ cordova platform remove ios
-$ cordova platform add ios
-$ cordova build ios
-```
-
-If no parameter is provided, it will only build the platform.
-
+iOS platform version.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -29,10 +29,33 @@ gulp.task('build', () => {
 
 This plugin will build the cordova project for the iOS platform.
 
-### Re-adding the iOS platform
+## API
+### ios(options)
+#### options
 
-The ```ios()``` method accepts one optional parameter. If the parameter passed in is ```true```, it will first
-remove the entire iOS platform and add it again.
+*Optional*
+
+Type: `object`
+
+A key-value pair object where the key is the name of the preference and the value the value. The keys and types are described below.
+
+##### options.reAdd 
+
+*Optional*
+
+Type: `boolean`
+
+If the value is `true`, this will cause the ios platform to be removed and re-added. 
+
+#### options.version
+
+*Optional*
+
+Type: `string`
+
+This will force the cordova to get the specified platform version of ios platform support.
+
+## Example
 
 ```js
 const gulp = require('gulp');
@@ -40,7 +63,7 @@ const ios = require('gulp-cordova-build-ios');
 
 gulp.task('rebuild', () => {
     return gulp.src('.cordova')
-        .pipe(ios(true));
+        .pipe(ios({ version: '3.9.2' }));
 });
 ```
 


### PR DESCRIPTION
This patch allows a developer to specify a particular version of cordova ios platform.
