### PR TITLE
Upgrade to latest version of cordova-lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ module.exports = function (options) {
 	options = options || {};
 	var device = options.device || true;
 	var release = options.release || false;
+	var codeSignIdentity = options.codeSignIdentity;
+	var provisioningProfile = options.provisioningProfile;
+	var developmentTeam = options.developmentTeam;
+	var packageType = options.packageType;
 
 	return through.obj(function (file, enc, cb) {
 		// Change the working directory
@@ -47,6 +51,18 @@ module.exports = function (options) {
 				}
 				if (release) {
 					options.push('--release');
+				}
+				if (codeSignIdentity) {
+					options.push('--codeSignIdentity=' + codeSignIdentity);
+				}
+				if (provisioningProfile) {
+					options.push('--provisioningProfile=' + provisioningProfile);
+				}
+				if (developmentTeam) {
+					options.push('--developmentTeam=' + developmentTeam);
+				}
+				if (packageType) {
+					options.push('--packageType=' + packageType);
 				}
 
 				// Build the platform

--- a/index.js
+++ b/index.js
@@ -44,7 +44,9 @@ module.exports = function (options) {
 			})
 			.catch(function (err) {
 				// Return an error if something happened
-				cb(new gutil.PluginError('gulp-cordova-build-ios', err.message));
+				// XXX: The 'ios-deploy was not found' error appears as a string, not as an Error instance.
+				var message = typeof err === 'string' ? err : err.message;
+				cb(new gutil.PluginError('gulp-cordova-build-ios', message));
 			});
 	});
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ios"
   ],
   "dependencies": {
-    "cordova-lib": "6.2.0",
+    "cordova-lib": "^6.4.0",
     "gulp-util": "^3.0.4",
     "pinkie-promise": "^2.0.0",
     "through2": "^2.0.0"

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,8 @@ gulp.task('build', () => {
         .pipe(create())
         .pipe(plugin('org.apache.cordova.dialogs'))
         .pipe(plugin('org.apache.cordova.camera'))
-        .pipe(ios());
+        .pipe(ios())
+        .pipe('ios');
 });
 ```
 
@@ -43,12 +44,44 @@ Default: `false`
 
 If the value is `true`, this will cause the ios platform to be removed and re-added.
 
-#### version
+##### version
 
 Type: `string`
 
 iOS platform version.
 
+##### device
+
+Type: `boolean`<br>
+Default: `true`
+
+If the value is `true`, this will build .ipa file as result. 
+
+**You must provide build.json file in cordova project directory**
+
+```json
+{
+  "ios": {
+    "debug": {
+      "codeSignIdentitiy": "iPhone Developer",
+      "provisioningProfile": "your-dev-provisioning-profile-UUID-here"
+    },
+    "release": {
+      "codeSignIdentitiy": "iPhone Distribution",
+      "provisioningProfile": "your-distribution-provisioning-profile-UUID-her"
+    }
+  }
+}
+```
+
+To get the UUID I open the .mobileprovision file on a text editor and search for 'UUID', not sure if there is an easier way of finding it.
+
+##### release
+
+Type: `boolean`<br>
+Default: `false`
+
+If the value is `true`, this will build .ipa and sign it with release certificates
 
 ## Related
 


### PR DESCRIPTION
The cordova-lib version was fixed because cordova-lib-6.3 broke gulp-cordova-build-ios (see https://github.com/SamVerschueren/gulp-cordova-build-ios/issues/12). The latest cordova-lib version 6.4 works again with gulp-cordova-build-ios.