### PR TITLE
Upgrade to latest version of cordova-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ios"
   ],
   "dependencies": {
-    "cordova-lib": "6.2.0",
+    "cordova-lib": "^6.4.0",
     "gulp-util": "^3.0.4",
     "pinkie-promise": "^2.0.0",
     "through2": "^2.0.0"


### PR DESCRIPTION
The cordova-lib version was fixed because cordova-lib-6.3 broke gulp-cordova-build-ios (see https://github.com/SamVerschueren/gulp-cordova-build-ios/issues/12). The latest cordova-lib version 6.4 works again with gulp-cordova-build-ios.