### PR TITLE
Add parameter to just add the platform and do not run the build

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,10 @@ module.exports = function (options) {
 				}
 			})
 			.then(function () {
-				// Build the platform
-				return cordova.build({platforms: ['ios']});
+				if(!options.justAdd) {
+					// Build the platform
+					return cordova.build({platforms: ['ios']});
+				}
 			})
 			.then(function () {
 				cb();

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,12 @@ Type: `string`
 
 iOS platform version.
 
+#### justAdd
+
+Type: `boolean`<br>
+Default: `false`
+
+If the value is `true`, this will just add the platform to the project and do not start the build.
 
 ## Related
 


### PR DESCRIPTION
In some cases it is helpful to just add the platform (e.g. test in iOS Simulator before build the app). So it would be great to add this parameter to the project. 